### PR TITLE
Add GlobalRenderSettings.GlobalRenderMode property to control render mode

### DIFF
--- a/MyApp.Shared/Components/Pages/Counter.razor
+++ b/MyApp.Shared/Components/Pages/Counter.razor
@@ -1,5 +1,5 @@
 ﻿@page "/counter"
-@rendermode @(GlobalRenderSettings.GlobalRenderMode)
+@rendermode InteractiveRenderMode
 
 <h1>Counter</h1>
 

--- a/MyApp.Shared/Components/Pages/Counter.razor
+++ b/MyApp.Shared/Components/Pages/Counter.razor
@@ -1,4 +1,5 @@
 ﻿@page "/counter"
+@rendermode @(GlobalRenderSettings.GlobalRenderMode)
 
 <h1>Counter</h1>
 

--- a/MyApp.Shared/GlobalRenderSettings.cs
+++ b/MyApp.Shared/GlobalRenderSettings.cs
@@ -1,7 +1,0 @@
-﻿namespace MyApp.Shared
-{
-    public static class GlobalRenderSettings
-    {
-        public static Microsoft.AspNetCore.Components.IComponentRenderMode? GlobalRenderMode { get; set; }
-    }
-}

--- a/MyApp.Shared/GlobalRenderSettings.cs
+++ b/MyApp.Shared/GlobalRenderSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace MyApp.Shared
+{
+    public static class GlobalRenderSettings
+    {
+        public static Microsoft.AspNetCore.Components.IComponentRenderMode? GlobalRenderMode { get; set; }
+    }
+}

--- a/MyApp.Shared/InteractiveRenderSettings.cs
+++ b/MyApp.Shared/InteractiveRenderSettings.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace MyApp.Shared
+{
+    public static class InteractiveRenderSettings
+    {
+        public static IComponentRenderMode? InteractiveRenderMode { get; set; }
+    }
+}

--- a/MyApp.Shared/_Imports.razor
+++ b/MyApp.Shared/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using MyApp.Shared
 @using MyApp.Shared.Components
+@using static InteractiveRenderSettings

--- a/MyApp.Shared/_Imports.razor
+++ b/MyApp.Shared/_Imports.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using MyApp.Shared

--- a/MyApp.Web/Program.cs
+++ b/MyApp.Web/Program.cs
@@ -1,6 +1,9 @@
+using MyApp.Shared;
 using MyApp.Shared.Interfaces;
 using MyApp.Web.Components;
-using MyApp.Web.Services;   
+using MyApp.Web.Services;
+
+GlobalRenderSettings.GlobalRenderMode = Microsoft.AspNetCore.Components.Web.RenderMode.InteractiveServer;
 
 
 var builder = WebApplication.CreateBuilder(args);

--- a/MyApp.Web/Program.cs
+++ b/MyApp.Web/Program.cs
@@ -3,7 +3,8 @@ using MyApp.Shared.Interfaces;
 using MyApp.Web.Components;
 using MyApp.Web.Services;
 
-GlobalRenderSettings.GlobalRenderMode = Microsoft.AspNetCore.Components.Web.RenderMode.InteractiveServer;
+// Set the interactive render mode for components in the Shared class library
+InteractiveRenderSettings.InteractiveRenderMode = Microsoft.AspNetCore.Components.Web.RenderMode.InteractiveServer;
 
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
Each project consuming the shared RazorClassLibrary can set the render mode to a desired value (or leave it as null).

What this solves is:
* Setting any explicit value in a `@rendermode` directive of a components will by default throw in a Blazor Hybrid app due to this exception: https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/RenderTree/Renderer.cs#L1250
* But if the value is `null` then the code that throws isn't even called: https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ComponentFactory.cs#L54

@BethMassi @SteveSandersonMS @javiercn @danroth27 