### PR TITLE
Try setting @rendermode attribute on component (it works!)

### DIFF
--- a/MyApp.Shared/Components/CounterComponent.razor
+++ b/MyApp.Shared/Components/CounterComponent.razor
@@ -1,0 +1,14 @@
+﻿<h1>Counter Component</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}

--- a/MyApp.Shared/Components/Pages/Home.razor
+++ b/MyApp.Shared/Components/Pages/Home.razor
@@ -5,3 +5,5 @@
 Welcome to your new app.
 
 <Component1 />
+
+<CounterComponent @rendermode="@(GlobalRenderSettings.GlobalRenderMode)" />


### PR DESCRIPTION
Per the Blazor sync discussion today, I tried setting `<SomeComponent @rendermode="@(SomeGlobalValue)" />` to see if the pattern works here as well. And, it seems it does! I tried in Blazor Web and .NET MAUI Blazor Hybrid. I also tried with 'invalid' values (like using WASM without it being enabled) just to ensure the code was executing and not merely being ignored.

This PR is just to show that it works and isn't something needed for the template.